### PR TITLE
🐛 introducing additional channels on each error handler

### DIFF
--- a/v2/error_handler.go
+++ b/v2/error_handler.go
@@ -19,14 +19,25 @@ import (
 // To render an error, just send it into the channel using the following syntax:
 //
 //	nativeErrorChannel<-err
+//
+// Due to the way channels work in golang to stop the handler from returning too
+// early and triggering errors with the transmitted content length, the
+// NativeErrorHandler adds a boolean channel called "nativeErrorHandled". This
+// channel needs to be listened to using the following syntax to stop the
+// handler sending the error from returning too early
+//
+//		nativeErrorHandled := r.Context().Value("nativeErrorHandled").(chan bool)
+//	 <-nativeErrorHandled
 func NativeErrorHandler(serviceName string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// create a new channel
 			c := make(chan error)
+			b := make(chan bool)
 			// now access the request context
 			ctx := r.Context()
 			ctx = context.WithValue(ctx, "nativeErrorChannel", c)
+			ctx = context.WithValue(ctx, "nativeErrorHandled", b)
 			// use a go function to listen to the channel and output the
 			// request error to the client using json
 			go func() {
@@ -36,6 +47,7 @@ func NativeErrorHandler(serviceName string) func(http.Handler) http.Handler {
 						e := wisdomType.WISdoMError{}
 						e.WrapError(err, serviceName)
 						_ = e.Send(w)
+						b <- true
 						return
 					}
 				}
@@ -61,14 +73,25 @@ func NativeErrorHandler(serviceName string) func(http.Handler) http.Handler {
 //
 // If an unregistered error code is used a panic will be released in the go
 // function handling the actual rendering
+//
+// Due to the way channels work in golang to stop the handler from returning too
+// early and triggering errors with the transmitted content length, the
+// WISdoMErrorHandler adds a boolean channel called "wisdomErrorHandled". This
+// channel needs to be listened to using the following syntax to stop the
+// handler sending the error from returning too early
+//
+//		wisdomErrorHandled := r.Context().Value("wisdomErrorChannel").(chan bool)
+//	 <-wisdomErrorHandled
 func WISdoMErrorHandler(errors map[string]wisdomType.WISdoMError) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// create a new channel
 			c := make(chan string)
+			b := make(chan bool)
 			// now access the request context
 			ctx := r.Context()
 			ctx = context.WithValue(ctx, "wisdomErrorChannel", c)
+			ctx = context.WithValue(ctx, "wisdomErrorHandled", b)
 			// use a go function to listen to the channel and output the
 			// request error to the client using json
 			go func() {


### PR DESCRIPTION
these additional channels may be used to block the further execution of the code in the handler using the channels to send errors.